### PR TITLE
Are some of the decoding examples missing?

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ bgr = cv2.imread('test_wm.png')
 
 decoder = WatermarkDecoder('bytes', 32)
 watermark = decoder.decode(bgr, 'dwtDct')
-print(watermark.decode('utf-8'))
+print(watermark.decode('utf-8','replace'))
 ```
 
 


### PR DESCRIPTION
It is assumed that " **,'replace'** " is needed after utf-8.
Now, please confirm that the "test" is displayed in the decoding run after encoding.