### PR TITLE
Make ONNX a soft depenedncy

### DIFF
--- a/imwatermark/rivaGan.py
+++ b/imwatermark/rivaGan.py
@@ -1,6 +1,5 @@
 import numpy as np
 import torch
-import onnxruntime
 import cv2
 import os
 import time
@@ -19,6 +18,14 @@ class RivaWatermark(object):
 
     @classmethod
     def loadModel(cls):
+        try:
+            import onnxruntime
+        except ImportError:
+            raise ImportError(
+                "The `RivaWatermark` class requires onnxruntime to be installed. "
+                "You can install it with pip: `pip install onnxruntime`."
+            )
+
         if RivaWatermark.encoder and RivaWatermark.decoder:
             return
         modelDir = os.path.dirname(os.path.abspath(__file__))

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,6 @@ setuptools.setup(
   install_requires=[
       'opencv-python>=4.1.0.25',
       'torch',
-      'onnx',
-      'onnxruntime',
       'Pillow>=6.0.0',
       'PyWavelets>=1.1.1',
       'numpy>=1.17.0'


### PR DESCRIPTION
Onnx and onnxruntime are not needed for most use cases, e.g. for SD-XL: one does not need `onnx` or `onnxruntime`: https://github.com/Stability-AI/generative-models#invisible-watermark-detection

Could we maybe make it a soft depenecy as the onnx packages are **very** heavy and can interact in unexpected/weird ways with PyTorch.