### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
   url='https://github.com/ShieldMnt/invisible-watermark',
   packages=setuptools.find_packages(),
   install_requires=[
-      'opencv-python>=4.1.0.25',
+      'opencv-python-headless>=4.1.0.25',
       'torch',
       'Pillow>=6.0.0',
       'PyWavelets>=1.1.1',


### PR DESCRIPTION
The dependency on invisible-watermark adds dependency on opencv. This line breaks a lot of dockerfiles. Can we switch to headless?